### PR TITLE
Add operator-based filtering for search

### DIFF
--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/edereagzi/portui/internal/types"
@@ -43,18 +44,21 @@ func filteredEntries(entries []types.PortEntry, query string) []types.PortEntry 
 
 	if query == "" {
 		result = deduped
-	} else {
+	} else if !hasOperatorToken(query) {
 		q := strings.ToLower(query)
 		result = make([]types.PortEntry, 0)
 
 		for _, e := range deduped {
-			portStr := fmt.Sprintf("%d", e.Port)
-			pidStr := fmt.Sprintf("%d", e.PID)
-			processLower := strings.ToLower(e.ProcessName)
+			if matchesPlainToken(e, q) {
+				result = append(result, e)
+			}
+		}
+	} else {
+		result = make([]types.PortEntry, 0)
+		tokens := strings.Fields(query)
 
-			if strings.Contains(portStr, q) ||
-				strings.Contains(processLower, q) ||
-				strings.HasPrefix(pidStr, q) {
+		for _, e := range deduped {
+			if matchesAllTokens(e, tokens) {
 				result = append(result, e)
 			}
 		}
@@ -65,4 +69,58 @@ func filteredEntries(entries []types.PortEntry, query string) []types.PortEntry 
 	})
 
 	return result
+}
+
+func hasOperatorToken(query string) bool {
+	for _, token := range strings.Fields(query) {
+		field, _, ok := strings.Cut(token, ":")
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(field) {
+		case "port", "proc", "pid", "user":
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAllTokens(e types.PortEntry, tokens []string) bool {
+	for _, token := range tokens {
+		if !matchesToken(e, token) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesToken(e types.PortEntry, token string) bool {
+	field, value, ok := strings.Cut(token, ":")
+	if ok {
+		value = strings.TrimSpace(value)
+		switch strings.ToLower(field) {
+		case "port":
+			port, err := strconv.Atoi(value)
+			return err == nil && uint16(port) == e.Port
+		case "proc":
+			return strings.Contains(strings.ToLower(e.ProcessName), strings.ToLower(value))
+		case "pid":
+			pid, err := strconv.Atoi(value)
+			return err == nil && int32(pid) == e.PID
+		case "user":
+			return strings.Contains(strings.ToLower(e.User), strings.ToLower(value))
+		}
+	}
+
+	return matchesPlainToken(e, strings.ToLower(token))
+}
+
+func matchesPlainToken(e types.PortEntry, token string) bool {
+	portStr := fmt.Sprintf("%d", e.Port)
+	pidStr := fmt.Sprintf("%d", e.PID)
+	processLower := strings.ToLower(e.ProcessName)
+
+	return strings.Contains(portStr, token) ||
+		strings.Contains(processLower, token) ||
+		strings.HasPrefix(pidStr, token)
 }

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -255,3 +255,74 @@ func TestFilteredEntriesSortedByPort(t *testing.T) {
 		}
 	}
 }
+
+func TestSearchOperatorPort(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "port:3000")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for port:3000, got %d", len(results))
+	}
+	if results[0].Port != 3000 {
+		t.Fatalf("expected port 3000, got %d", results[0].Port)
+	}
+}
+
+func TestSearchOperatorProc(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "proc:node")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results for proc:node, got %d", len(results))
+	}
+	for _, e := range results {
+		if !strings.Contains(strings.ToLower(e.ProcessName), "node") {
+			t.Fatalf("unexpected process in proc filter: %+v", e)
+		}
+	}
+}
+
+func TestSearchOperatorPID(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "pid:1234")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for pid:1234, got %d", len(results))
+	}
+	if results[0].PID != 1234 {
+		t.Fatalf("expected PID 1234, got %d", results[0].PID)
+	}
+}
+
+func TestSearchOperatorUser(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "user:postgres")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for user:postgres, got %d", len(results))
+	}
+	if results[0].User != "postgres" {
+		t.Fatalf("expected user postgres, got %q", results[0].User)
+	}
+}
+
+func TestSearchOperatorAndLogic(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "proc:node user:eray port:3000")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for AND query, got %d", len(results))
+	}
+	if results[0].Port != 3000 || results[0].PID != 1001 {
+		t.Fatalf("unexpected result for AND query: %+v", results[0])
+	}
+}
+
+func TestSearchPlainTextFallbackUnchanged(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "node")
+	if len(results) != 2 {
+		t.Fatalf("expected plain-text behavior to remain unchanged for 'node', got %d", len(results))
+	}
+}


### PR DESCRIPTION
## Summary
- add operator-based filtering for `port:`, `proc:`, `pid:`, and `user:`
- keep existing plain-text search behavior when no operators are used
- apply AND logic across tokens when operator mode is active

## Linked Issue
Closes #6

## What Changed
- added operator parsing/matching helpers in `internal/tui/search.go`
- introduced exact matching for `port:` and `pid:` operators
- added tests for operator filters and AND behavior in `internal/tui/search_test.go`

## Validation
- [x] `go test ./...`
- [x] `go build ./...`

## Checklist
- [x] Branch name follows convention (`feature/<issue>-slug`, `bug/<issue>-slug`, `task/<issue>-slug`)
- [x] PR scope matches linked issue
- [x] No unrelated changes included