### PR TITLE
Add kill impact summary to confirmation dialog

### DIFF
--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -2,7 +2,9 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
+	"strings"
 
 	"charm.land/bubbles/v2/table"
 	"charm.land/lipgloss/v2"
@@ -30,14 +32,62 @@ func selectedPortEntry(entries []types.PortEntry, row table.Row) *types.PortEntr
 	return nil
 }
 
-func confirmKillView(entry *types.PortEntry, width int) string {
+func confirmKillView(entry *types.PortEntry, impactPorts []uint16, width int) string {
 	if entry == nil {
 		return ""
 	}
-	text := fmt.Sprintf("Kill %s (PID %d) on port %d? [y]es / [n]o", entry.ProcessName, entry.PID, entry.Port)
+	impact := formatImpactSummary(impactPorts)
+	text := fmt.Sprintf("Kill %s (PID %d) on port %d? [y]es / [n]o\n%s", entry.ProcessName, entry.PID, entry.Port, impact)
 	rendered := ConfirmDialogStyle.Render(text)
 	if width > 0 {
 		rendered = lipgloss.NewStyle().Width(width).Align(lipgloss.Center).Render(rendered)
 	}
 	return rendered
+}
+
+func impactedPortsByPID(entries []types.PortEntry, pid int32) []uint16 {
+	seen := make(map[uint16]struct{})
+	ports := make([]uint16, 0)
+	for _, e := range entries {
+		if e.PID != pid {
+			continue
+		}
+		if _, ok := seen[e.Port]; ok {
+			continue
+		}
+		seen[e.Port] = struct{}{}
+		ports = append(ports, e.Port)
+	}
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i] < ports[j]
+	})
+	return ports
+}
+
+func formatImpactSummary(ports []uint16) string {
+	count := len(ports)
+	if count == 0 {
+		return "Affects 0 listening ports"
+	}
+	if count == 1 {
+		return fmt.Sprintf("Affects 1 listening port: %d", ports[0])
+	}
+
+	limit := 6
+	shown := ports
+	if len(shown) > limit {
+		shown = shown[:limit]
+	}
+
+	parts := make([]string, 0, len(shown))
+	for _, p := range shown {
+		parts = append(parts, fmt.Sprintf("%d", p))
+	}
+
+	more := ""
+	if count > limit {
+		more = fmt.Sprintf(" (+%d more)", count-limit)
+	}
+
+	return fmt.Sprintf("Affects %d listening ports: %s%s", count, strings.Join(parts, ", "), more)
 }

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -199,3 +199,78 @@ func TestKillShowsPendingStatus(t *testing.T) {
 		t.Fatal("expected non-nil cmd for async kill")
 	}
 }
+
+func TestConfirmKillViewShowsImpactSummaryMultiPort(t *testing.T) {
+	entry := &types.PortEntry{Port: 3000, PID: 1001, ProcessName: "node", Protocol: "tcp", User: "eray", LocalAddr: "127.0.0.1"}
+	entries := []types.PortEntry{
+		{Port: 3000, PID: 1001, ProcessName: "node", Protocol: "tcp", User: "eray", LocalAddr: "127.0.0.1"},
+		{Port: 3001, PID: 1001, ProcessName: "node", Protocol: "tcp", User: "eray", LocalAddr: "127.0.0.1"},
+		{Port: 5432, PID: 4321, ProcessName: "postgres", Protocol: "tcp", User: "postgres", LocalAddr: "127.0.0.1"},
+	}
+
+	view := confirmKillView(entry, impactedPortsByPID(entries, entry.PID), 0)
+	if !strings.Contains(view, "Affects 2 listening ports") {
+		t.Fatalf("expected impact summary in confirm dialog, got: %q", view)
+	}
+	if !strings.Contains(view, "3000") || !strings.Contains(view, "3001") {
+		t.Fatalf("expected affected port list in confirm dialog, got: %q", view)
+	}
+}
+
+func TestConfirmKillViewShowsSinglePortImpact(t *testing.T) {
+	entry := &types.PortEntry{Port: 8080, PID: 1234, ProcessName: "api-server", Protocol: "tcp", User: "eray", LocalAddr: "127.0.0.1"}
+	entries := []types.PortEntry{
+		{Port: 8080, PID: 1234, ProcessName: "api-server", Protocol: "tcp", User: "eray", LocalAddr: "127.0.0.1"},
+	}
+
+	view := confirmKillView(entry, impactedPortsByPID(entries, entry.PID), 0)
+	if !strings.Contains(view, "Affects 1 listening port") {
+		t.Fatalf("expected single-port impact summary, got: %q", view)
+	}
+}
+
+func TestFormatImpactSummaryZero(t *testing.T) {
+	got := formatImpactSummary(nil)
+	if got != "Affects 0 listening ports" {
+		t.Fatalf("expected zero-case summary, got %q", got)
+	}
+}
+
+func TestFormatImpactSummaryTruncatesLongPortList(t *testing.T) {
+	ports := []uint16{1000, 1001, 1002, 1003, 1004, 1005, 1006}
+	got := formatImpactSummary(ports)
+	if !strings.Contains(got, "Affects 7 listening ports") {
+		t.Fatalf("expected total count in summary, got %q", got)
+	}
+	if !strings.Contains(got, "(+1 more)") {
+		t.Fatalf("expected overflow suffix in summary, got %q", got)
+	}
+}
+
+func TestConfirmImpactSnapshotStaysStableDuringRefresh(t *testing.T) {
+	svc := &mockProcessServiceKill{}
+	entries := []types.PortEntry{
+		{Port: 3000, Protocol: "tcp", PID: 1001, ProcessName: "node", User: "eray", LocalAddr: "127.0.0.1"},
+		{Port: 3001, Protocol: "tcp", PID: 1001, ProcessName: "node", User: "eray", LocalAddr: "127.0.0.1"},
+	}
+	m := New(mockScanner{}, svc)
+	updated, _ := m.Update(portsLoadedMsg{entries: entries})
+	m = updated.(Model)
+
+	updated2, _ := m.Update(tea.KeyPressMsg{Text: "x"})
+	m = updated2.(Model)
+
+	if got := formatImpactSummary(m.confirmImpactPorts); !strings.Contains(got, "Affects 2 listening ports") {
+		t.Fatalf("expected initial snapshot to show 2 ports, got %q", got)
+	}
+
+	refreshEntries := []types.PortEntry{
+		{Port: 5432, Protocol: "tcp", PID: 4321, ProcessName: "postgres", User: "postgres", LocalAddr: "127.0.0.1"},
+	}
+	updated3, _ := m.Update(portsLoadedMsg{entries: refreshEntries})
+	m = updated3.(Model)
+
+	if got := formatImpactSummary(m.confirmImpactPorts); !strings.Contains(got, "Affects 2 listening ports") {
+		t.Fatalf("expected snapshot to remain stable during confirm state, got %q", got)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -25,21 +25,22 @@ const (
 )
 
 type Model struct {
-	scanner        types.PortScanner
-	processService types.ProcessService
-	entries        []types.PortEntry
-	filtered       []types.PortEntry
-	table          table.Model
-	state          appState
-	width          int
-	height         int
-	err            error
-	filterText     string
-	filterInput    textinput.Model
-	selectedEntry  *types.PortEntry
-	detailInfo     *types.ProcessInfo
-	statusMsg      string
-	statusIsErr    bool
+	scanner            types.PortScanner
+	processService     types.ProcessService
+	entries            []types.PortEntry
+	filtered           []types.PortEntry
+	table              table.Model
+	state              appState
+	width              int
+	height             int
+	err                error
+	filterText         string
+	filterInput        textinput.Model
+	selectedEntry      *types.PortEntry
+	confirmImpactPorts []uint16
+	detailInfo         *types.ProcessInfo
+	statusMsg          string
+	statusIsErr        bool
 }
 
 func New(scanner types.PortScanner, processService types.ProcessService) Model {
@@ -59,7 +60,7 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(scanPortsCmd(m.scanner), tickCmd())
 }
 
-const confirmDialogLines = 5
+const confirmDialogLines = 6
 
 func (m *Model) rebuildTable() {
 	prevRow := m.table.SelectedRow()
@@ -100,6 +101,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusIsErr = false
 		}
 		m.selectedEntry = nil
+		m.confirmImpactPorts = nil
 		m.state = stateTable
 		m.rebuildTable()
 		return m, tea.Batch(scanPortsCmd(m.scanner), statusClearCmd())
@@ -146,6 +148,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if key.Matches(msg, Keys.Kill) && m.selectedEntry != nil {
+				m.confirmImpactPorts = impactedPortsByPID(m.entries, m.selectedEntry.PID)
 				m.state = stateConfirmKill
 				m.rebuildTable()
 				return m, nil
@@ -180,6 +183,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if entry != nil {
 					entryCopy := *entry
 					m.selectedEntry = &entryCopy
+					m.confirmImpactPorts = impactedPortsByPID(m.entries, entryCopy.PID)
 					m.state = stateConfirmKill
 					m.rebuildTable()
 				}
@@ -198,6 +202,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.state == stateConfirmKill {
 			if key.Matches(msg, Keys.Esc) || msg.Text == "n" {
 				m.selectedEntry = nil
+				m.confirmImpactPorts = nil
 				m.state = stateTable
 				m.rebuildTable()
 				return m, nil
@@ -323,7 +328,7 @@ func (m Model) renderTableView(width int) string {
 	}
 	topParts = append(topParts, body)
 	if m.state == stateConfirmKill {
-		topParts = append(topParts, confirmKillView(m.selectedEntry, renderWidth))
+		topParts = append(topParts, confirmKillView(m.selectedEntry, m.confirmImpactPorts, renderWidth))
 	}
 
 	top := lipgloss.JoinVertical(lipgloss.Left, topParts...)


### PR DESCRIPTION
## Summary
- show kill impact summary in confirm dialog
- display affected listening port count and compact port list
- keep summary stable during confirm flow using snapshot data

## Linked Issue
Closes #7

## What Changed
- updated `confirmKillView` to render from snapshot impact ports
- added impact helpers for PID-based port extraction and summary formatting
- stored `confirmImpactPorts` in model when entering confirm state
- cleared confirm snapshot on cancel/success transitions
- added regression tests for zero-case, truncation, and refresh stability

## Validation
- [x] `go test ./...`
- [x] `go build ./...`

## Checklist
- [x] Branch name follows convention (`feature/<issue>-slug`, `bug/<issue>-slug`, `task/<issue>-slug`)
- [x] PR scope matches linked issue
- [x] No unrelated changes included