### PR TITLE
Harden operator query validation for search

### DIFF
--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -97,17 +97,30 @@ func matchesAllTokens(e types.PortEntry, tokens []string) bool {
 func matchesToken(e types.PortEntry, token string) bool {
 	field, value, ok := strings.Cut(token, ":")
 	if ok {
+		field = strings.ToLower(strings.TrimSpace(field))
 		value = strings.TrimSpace(value)
-		switch strings.ToLower(field) {
+		switch field {
 		case "port":
 			port, err := strconv.Atoi(value)
-			return err == nil && uint16(port) == e.Port
+			if err != nil || port < 0 || port > 65535 {
+				return false
+			}
+			return uint16(port) == e.Port
 		case "proc":
+			if value == "" {
+				return false
+			}
 			return strings.Contains(strings.ToLower(e.ProcessName), strings.ToLower(value))
 		case "pid":
 			pid, err := strconv.Atoi(value)
-			return err == nil && int32(pid) == e.PID
+			if err != nil || pid < 0 || pid > 2147483647 {
+				return false
+			}
+			return int32(pid) == e.PID
 		case "user":
+			if value == "" {
+				return false
+			}
 			return strings.Contains(strings.ToLower(e.User), strings.ToLower(value))
 		}
 	}

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -326,3 +326,51 @@ func TestSearchPlainTextFallbackUnchanged(t *testing.T) {
 		t.Fatalf("expected plain-text behavior to remain unchanged for 'node', got %d", len(results))
 	}
 }
+
+func TestSearchOperatorPortRejectsNegativeValue(t *testing.T) {
+	entries := []types.PortEntry{
+		{Port: 65535, Protocol: "tcp", PID: 4242, ProcessName: "edge", User: "eray", LocalAddr: "127.0.0.1"},
+	}
+	m := newLoadedModel(entries)
+
+	results := filteredEntries(m.entries, "port:-1")
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for invalid port:-1, got %d", len(results))
+	}
+}
+
+func TestSearchOperatorPortRejectsOutOfRangeValue(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "port:70000")
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for invalid port:70000, got %d", len(results))
+	}
+}
+
+func TestSearchOperatorPIDRejectsOutOfRangeValue(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "pid:2147483648")
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for invalid pid:2147483648, got %d", len(results))
+	}
+}
+
+func TestSearchOperatorProcRejectsEmptyValue(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "proc:")
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for invalid proc:, got %d", len(results))
+	}
+}
+
+func TestSearchOperatorUserRejectsEmptyValue(t *testing.T) {
+	m := newLoadedModel(searchTestEntries())
+
+	results := filteredEntries(m.entries, "user:")
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for invalid user:, got %d", len(results))
+	}
+}


### PR DESCRIPTION
## Summary
- harden operator parsing/validation for search queries
- reject malformed empty operator values consistently
- reject invalid numeric ranges for `port:` and `pid:`

## Linked Issue
Related to #6

## What Changed
- `port:` now rejects negative/out-of-range values before comparison
- `pid:` now rejects negative/out-of-range values before comparison
- `proc:` and `user:` now reject empty values (e.g. `proc:`)
- added regression tests for malformed and out-of-range operator queries

## Validation
- [x] `go test ./...`
- [x] `go build ./...`

## Checklist
- [x] Branch name follows convention (`feature/<issue>-slug`, `bug/<issue>-slug`, `task/<issue>-slug`)
- [x] PR scope matches linked issue
- [x] No unrelated changes included