### PR TITLE
Add self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ portui
 
 No flags or configuration needed. portui will scan your system for listening ports and display them in an interactive terminal UI.
 
+Update to latest release:
+
+```bash
+portui update
+```
+
+Note: self-update supports direct installs on macOS/Linux where the current `portui` binary path is writable.
+
 ## Keybindings
 
 | Key | Action |

--- a/cmd/portui/main.go
+++ b/cmd/portui/main.go
@@ -8,17 +8,42 @@ import (
 	"github.com/edereagzi/portui/internal/process"
 	"github.com/edereagzi/portui/internal/scanner"
 	"github.com/edereagzi/portui/internal/tui"
+	"github.com/edereagzi/portui/internal/update"
 )
 
 var version = "dev"
 
+func usage() {
+	fmt.Fprintf(flag.CommandLine.Output(), "Usage: portui [flags] [command]\n\n")
+	fmt.Fprintf(flag.CommandLine.Output(), "Commands:\n")
+	fmt.Fprintf(flag.CommandLine.Output(), "  update    Update portui to the latest release\n\n")
+	fmt.Fprintf(flag.CommandLine.Output(), "Flags:\n")
+	flag.PrintDefaults()
+}
+
 func main() {
+	flag.Usage = usage
 	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.BoolVar(showVersion, "v", false, "print version and exit (shorthand)")
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Printf("portui %s\n", version)
+		os.Exit(0)
+	}
+
+	args := flag.Args()
+	if len(args) > 0 && args[0] == "update" {
+		latest, updated, err := update.Run(version)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: update failed: %v\n", err)
+			os.Exit(1)
+		}
+		if updated {
+			fmt.Printf("updated to %s\n", latest)
+		} else {
+			fmt.Printf("already up to date (%s)\n", latest)
+		}
 		os.Exit(0)
 	}
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,202 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const repo = "edereagzi/portui"
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+func Run(currentVersion string) (string, bool, error) {
+	osName, arch, err := platform()
+	if err != nil {
+		return "", false, err
+	}
+
+	latestTag, err := latestTag()
+	if err != nil {
+		return "", false, err
+	}
+
+	if currentVersion != "dev" && sameVersion(currentVersion, latestTag) {
+		return latestTag, false, nil
+	}
+
+	assetName := fmt.Sprintf("portui_%s_%s.tar.gz", osName, arch)
+	base := fmt.Sprintf("https://github.com/%s/releases/download/%s", repo, latestTag)
+	assetURL := fmt.Sprintf("%s/%s", base, assetName)
+	checksumsURL := fmt.Sprintf("%s/checksums.txt", base)
+
+	archiveBytes, err := download(assetURL)
+	if err != nil {
+		return "", false, fmt.Errorf("download release asset: %w", err)
+	}
+	checksumsBytes, err := download(checksumsURL)
+	if err != nil {
+		return "", false, fmt.Errorf("download checksums: %w", err)
+	}
+
+	expected, err := checksumForAsset(string(checksumsBytes), assetName)
+	if err != nil {
+		return "", false, err
+	}
+	actual := sha256Sum(archiveBytes)
+	if expected != actual {
+		return "", false, fmt.Errorf("checksum mismatch for %s", assetName)
+	}
+
+	binaryBytes, err := extractBinary(archiveBytes)
+	if err != nil {
+		return "", false, err
+	}
+
+	if err := replaceCurrentExecutable(binaryBytes); err != nil {
+		return "", false, err
+	}
+
+	return latestTag, true, nil
+}
+
+func latestTag() (string, error) {
+	respBytes, err := download("https://api.github.com/repos/" + repo + "/releases/latest")
+	if err != nil {
+		return "", fmt.Errorf("fetch latest release: %w", err)
+	}
+	var release githubRelease
+	if err := json.Unmarshal(respBytes, &release); err != nil {
+		return "", fmt.Errorf("parse release metadata: %w", err)
+	}
+	if release.TagName == "" {
+		return "", errors.New("latest release tag is empty")
+	}
+	return release.TagName, nil
+}
+
+func platform() (string, string, error) {
+	var osName string
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		osName = runtime.GOOS
+	default:
+		return "", "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+
+	var arch string
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+		arch = runtime.GOARCH
+	default:
+		return "", "", fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+	}
+
+	return osName, arch, nil
+}
+
+func sameVersion(current, latest string) bool {
+	return strings.TrimPrefix(current, "v") == strings.TrimPrefix(latest, "v")
+}
+
+func download(url string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "portui-self-update")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download failed: %s", resp.Status)
+	}
+
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+func checksumForAsset(checksums, asset string) (string, error) {
+	for _, line := range strings.Split(checksums, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[1] == asset {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("checksum not found for %s", asset)
+}
+
+func sha256Sum(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func extractBinary(archive []byte) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Base(hdr.Name) == "portui" {
+			return io.ReadAll(tr)
+		}
+	}
+
+	return nil, errors.New("portui binary not found in archive")
+}
+
+func replaceCurrentExecutable(binary []byte) error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	tempPath := exePath + ".new"
+
+	if err := os.WriteFile(tempPath, binary, 0o755); err != nil {
+		return fmt.Errorf("write temp binary: %w", err)
+	}
+	if err := os.Rename(tempPath, exePath); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("replace executable: %w", err)
+	}
+	return nil
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,133 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestChecksumForAsset(t *testing.T) {
+	checksums := "abc123  portui_darwin_arm64.tar.gz\ndef456  another.tar.gz"
+
+	got, err := checksumForAsset(checksums, "portui_darwin_arm64.tar.gz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "abc123" {
+		t.Fatalf("expected abc123, got %q", got)
+	}
+}
+
+func TestChecksumForAssetNotFound(t *testing.T) {
+	checksums := "abc123  portui_darwin_arm64.tar.gz"
+
+	_, err := checksumForAsset(checksums, "missing.tar.gz")
+	if err == nil {
+		t.Fatal("expected error when checksum entry is missing")
+	}
+}
+
+func TestSameVersion(t *testing.T) {
+	if !sameVersion("v1.2.3", "1.2.3") {
+		t.Fatal("expected versions to be treated as same")
+	}
+	if sameVersion("1.2.3", "1.2.4") {
+		t.Fatal("expected different versions to not match")
+	}
+}
+
+func TestExtractBinary(t *testing.T) {
+	archive := buildTarGz(t, map[string]string{
+		"README.md": "hello",
+		"portui":    "binary-content",
+	})
+
+	got, err := extractBinary(archive)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "binary-content" {
+		t.Fatalf("unexpected binary content: %q", string(got))
+	}
+}
+
+func TestExtractBinaryNotFound(t *testing.T) {
+	archive := buildTarGz(t, map[string]string{
+		"README.md": "hello",
+	})
+
+	_, err := extractBinary(archive)
+	if err == nil {
+		t.Fatal("expected error when binary is missing")
+	}
+}
+
+func TestDownloadSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	originalClient := httpClient
+	httpClient = server.Client()
+	t.Cleanup(func() {
+		httpClient = originalClient
+	})
+
+	got, err := download(server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "ok" {
+		t.Fatalf("expected 'ok', got %q", string(got))
+	}
+}
+
+func TestDownloadNon2xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	originalClient := httpClient
+	httpClient = server.Client()
+	t.Cleanup(func() {
+		httpClient = originalClient
+	})
+
+	_, err := download(server.URL)
+	if err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+}
+
+func buildTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("write body: %v", err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary
- add built-in `portui update` command
- fetch latest release metadata and download pinned-tag release asset
- verify archive with release checksums before extraction/install
- add command documentation to `-h` output and README

## Linked Issue
Closes #14

## What Changed
- integrate `update` command path in `cmd/portui/main.go`
- add self-update module in `internal/update/update.go`
- add tests in `internal/update/update_test.go`
- document update command usage in README

## Validation
- [x] `go test ./...`
- [x] `go build ./...`

## Checklist
- [x] Branch name follows convention (`feature/<issue>-slug`, `bug/<issue>-slug`, `task/<issue>-slug`)
- [x] PR scope matches linked issue
- [x] No unrelated changes included