### PR TITLE
Improve actionable scan and kill error messages

### DIFF
--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -153,6 +153,9 @@ func TestKillErrorShowsErrorMessage(t *testing.T) {
 	if !got.statusIsErr {
 		t.Fatal("expected statusIsErr to be true on error")
 	}
+	if strings.Count(got.statusMsg, "✗") != 1 {
+		t.Fatalf("expected single error prefix in status message, got %q", got.statusMsg)
+	}
 }
 
 func TestKillUsesSelectedRowPID(t *testing.T) {

--- a/internal/tui/errors.go
+++ b/internal/tui/errors.go
@@ -1,0 +1,48 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+func formatScanStatus(err error, staleCount int) string {
+	if err == nil {
+		return fmt.Sprintf("%d ports", staleCount)
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "permission denied") || strings.Contains(msg, "operation not permitted") || strings.Contains(msg, "not permitted"):
+		return fmt.Sprintf("⚠ Scan failed (permission denied) — %d ports (stale). Try running with sudo.", staleCount)
+	case strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "context deadline exceeded") || strings.Contains(msg, "timeout"):
+		return fmt.Sprintf("⚠ Scan timed out — %d ports (stale). Press r to retry.", staleCount)
+	case strings.Contains(msg, "executable file not found") && strings.Contains(msg, "lsof"):
+		return fmt.Sprintf("⚠ Scan failed (lsof not found) — %d ports (stale). Install lsof and retry.", staleCount)
+	default:
+		return fmt.Sprintf("⚠ Scan failed — %d ports (stale). Press r to retry.", staleCount)
+	}
+}
+
+func formatKillFailure(err error) string {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "permission denied") || strings.Contains(msg, "operation not permitted") || strings.Contains(msg, "not permitted"):
+		return fmt.Sprintf("✗ Kill failed: %s. Try running with sudo.", err)
+	case strings.Contains(msg, "no such process") || strings.Contains(msg, "process not found") || strings.Contains(msg, "already finished"):
+		return fmt.Sprintf("✗ Kill failed: %s. Process may already be gone.", err)
+	default:
+		return fmt.Sprintf("✗ Kill failed: %s. Try again with r then x.", err)
+	}
+}
+
+func formatProcessInfoFailure(err error) string {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "permission denied") || strings.Contains(msg, "operation not permitted") || strings.Contains(msg, "not permitted"):
+		return fmt.Sprintf("✗ Failed to read process info: %s. Try running with sudo.", err)
+	case strings.Contains(msg, "no such process") || strings.Contains(msg, "process not found") || strings.Contains(msg, "already finished"):
+		return fmt.Sprintf("✗ Failed to read process info: %s. Process may already be gone.", err)
+	default:
+		return fmt.Sprintf("✗ Failed to read process info: %s.", err)
+	}
+}

--- a/internal/tui/errors_test.go
+++ b/internal/tui/errors_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFormatScanStatusPermission(t *testing.T) {
+	msg := formatScanStatus(errors.New("permission denied"), 2)
+	if !strings.Contains(msg, "Try running with sudo") {
+		t.Fatalf("expected actionable sudo hint, got %q", msg)
+	}
+}
+
+func TestFormatScanStatusTimeout(t *testing.T) {
+	msg := formatScanStatus(errors.New("context deadline exceeded"), 3)
+	if !strings.Contains(msg, "Press r to retry") {
+		t.Fatalf("expected retry hint, got %q", msg)
+	}
+}
+
+func TestFormatScanStatusLsofMissing(t *testing.T) {
+	msg := formatScanStatus(errors.New("exec: \"lsof\": executable file not found in $PATH"), 1)
+	if !strings.Contains(msg, "Install lsof and retry") {
+		t.Fatalf("expected lsof installation hint, got %q", msg)
+	}
+}
+
+func TestFormatKillFailurePermission(t *testing.T) {
+	msg := formatKillFailure(errors.New("permission denied (PID 1)"))
+	if !strings.Contains(msg, "Try running with sudo") {
+		t.Fatalf("expected sudo hint for kill failure, got %q", msg)
+	}
+}
+
+func TestFormatKillFailureNotFound(t *testing.T) {
+	msg := formatKillFailure(errors.New("process not found (PID 9999)"))
+	if !strings.Contains(msg, "already be gone") {
+		t.Fatalf("expected process missing hint, got %q", msg)
+	}
+}
+
+func TestFormatProcessInfoFailurePermission(t *testing.T) {
+	msg := formatProcessInfoFailure(errors.New("operation not permitted"))
+	if !strings.Contains(msg, "Try running with sudo") {
+		t.Fatalf("expected sudo hint for process info failure, got %q", msg)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -94,7 +94,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(scanPortsCmd(m.scanner), tickCmd())
 	case killResultMsg:
 		if msg.err != nil {
-			m.statusMsg = fmt.Sprintf("✗ Failed: %s", msg.err)
+			m.statusMsg = formatKillFailure(msg.err)
 			m.statusIsErr = true
 		} else {
 			m.statusMsg = fmt.Sprintf("✓ Killed %s (PID %d)", msg.entry.ProcessName, msg.entry.PID)
@@ -162,7 +162,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if entry != nil {
 					info, err := m.processService.GetInfo(entry.PID)
 					if err != nil {
-						m.statusMsg = fmt.Sprintf("✗ Failed to get process info: %s", err.Error())
+						m.statusMsg = formatProcessInfoFailure(err)
 						m.statusIsErr = true
 						return m, statusClearCmd()
 					}
@@ -365,7 +365,7 @@ func (m Model) footerHints() string {
 
 func (m Model) statusLeft() string {
 	if m.err != nil {
-		return ErrorStyle.Render(fmt.Sprintf("⚠ Scan failed — %d ports (stale)", len(m.entries)))
+		return ErrorStyle.Render(formatScanStatus(m.err, len(m.entries)))
 	}
 	if m.statusMsg != "" {
 		style := SuccessStyle

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -33,6 +33,16 @@ func (mockProcessService) Kill(pid int32) error {
 	return nil
 }
 
+type mockProcessServiceInfoErr struct{}
+
+func (mockProcessServiceInfoErr) GetInfo(pid int32) (*types.ProcessInfo, error) {
+	return nil, errors.New("permission denied")
+}
+
+func (mockProcessServiceInfoErr) Kill(pid int32) error {
+	return nil
+}
+
 func testEntries() []types.PortEntry {
 	return []types.PortEntry{
 		{
@@ -162,5 +172,21 @@ func TestModelTableViewIncludesStatusBar(t *testing.T) {
 	}
 	if !strings.Contains(v.Content, "q: quit") {
 		t.Fatalf("expected footer help in view, got %q", v.Content)
+	}
+}
+
+func TestModelGetInfoErrorShowsActionableHint(t *testing.T) {
+	m := New(mockScanner{}, mockProcessServiceInfoErr{})
+	updated, _ := m.Update(portsLoadedMsg{entries: testEntries()})
+	m = updated.(Model)
+
+	updated2, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	got := updated2.(Model)
+
+	if !strings.Contains(got.statusMsg, "Try running with sudo") {
+		t.Fatalf("expected actionable sudo hint in process info error, got %q", got.statusMsg)
+	}
+	if !got.statusIsErr {
+		t.Fatal("expected statusIsErr to be true")
 	}
 }

--- a/internal/tui/polish_test.go
+++ b/internal/tui/polish_test.go
@@ -92,6 +92,9 @@ func TestScanErrorShowsInStatusBar(t *testing.T) {
 	if !strings.Contains(v.Content, "⚠ Scan failed") {
 		t.Fatalf("expected warning in status bar, got %q", v.Content)
 	}
+	if !strings.Contains(v.Content, "Try running with sudo") {
+		t.Fatalf("expected actionable sudo hint in scan error, got %q", v.Content)
+	}
 	if !strings.Contains(v.Content, "2 ports") {
 		t.Fatalf("expected stale port count to remain visible, got %q", v.Content)
 	}


### PR DESCRIPTION
## Summary
- improve scan/kill/process-info error texts with actionable guidance
- add targeted hints for permission, timeout, and missing `lsof` scenarios
- avoid noisy/duplicated error wording in user-facing status messages

## Linked Issue
Closes #9

## What Changed
- added error formatters in `internal/tui/errors.go`
- integrated formatter usage in `internal/tui/model.go`
- added/updated tests in:
  - `internal/tui/errors_test.go`
  - `internal/tui/actions_test.go`
  - `internal/tui/model_test.go`
  - `internal/tui/polish_test.go`

## Validation
- [x] `go test ./...`
- [x] `go build ./...`

## Checklist
- [x] Branch name follows convention (`feature/<issue>-slug`, `bug/<issue>-slug`, `task/<issue>-slug`)
- [x] PR scope matches linked issue
- [x] No unrelated changes included