### PR TITLE
Simplify bind column display in table

### DIFF
--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 
 	"charm.land/bubbles/v2/table"
 
@@ -15,7 +16,7 @@ func buildTable(entries []types.PortEntry, width, height int) table.Model {
 		{Title: "PID", Width: 8},
 		{Title: "Process", Width: 20},
 		{Title: "User", Width: 12},
-		{Title: "Address", Width: 20},
+		{Title: "Bind", Width: 16},
 	}
 
 	rows := make([]table.Row, 0, len(entries))
@@ -26,7 +27,7 @@ func buildTable(entries []types.PortEntry, width, height int) table.Model {
 			fmt.Sprintf("%d", entry.PID),
 			entry.ProcessName,
 			entry.User,
-			entry.LocalAddr,
+			bindHost(entry.LocalAddr),
 		})
 	}
 
@@ -55,4 +56,34 @@ func buildTable(entries []types.PortEntry, width, height int) table.Model {
 	}
 
 	return table.New(opts...)
+}
+
+func bindHost(localAddr string) string {
+	addr := strings.TrimSpace(localAddr)
+	if addr == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(addr, "*:") || addr == "*" {
+		return "0.0.0.0"
+	}
+	if strings.HasPrefix(addr, ":::") {
+		return "::"
+	}
+
+	if strings.HasPrefix(addr, "[") {
+		if end := strings.Index(addr, "]"); end > 1 {
+			return addr[1:end]
+		}
+	}
+
+	if idx := strings.LastIndex(addr, ":"); idx > 0 {
+		host := addr[:idx]
+		if host == "*" {
+			return "0.0.0.0"
+		}
+		return host
+	}
+
+	return addr
 }

--- a/internal/tui/table_test.go
+++ b/internal/tui/table_test.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/edereagzi/portui/internal/types"
+)
+
+func TestBindHost(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "wildcard star", in: "*:7000", want: "0.0.0.0"},
+		{name: "ipv4 local", in: "127.0.0.1:7265", want: "127.0.0.1"},
+		{name: "ipv4 any", in: "0.0.0.0:3000", want: "0.0.0.0"},
+		{name: "ipv6 any", in: ":::3000", want: "::"},
+		{name: "ipv6 loopback", in: "::1:3000", want: "::1"},
+		{name: "bracket ipv6", in: "[::1]:3000", want: "::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bindHost(tt.in)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBuildTableUsesBindHostWithoutPort(t *testing.T) {
+	entries := []types.PortEntry{{
+		Port:        7265,
+		Protocol:    "tcp",
+		PID:         1001,
+		ProcessName: "api",
+		User:        "eray",
+		LocalAddr:   "127.0.0.1:7265",
+	}}
+
+	tbl := buildTable(entries, 0, 0)
+	rows := tbl.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0][5] != "127.0.0.1" {
+		t.Fatalf("expected bind host only, got %q", rows[0][5])
+	}
+}


### PR DESCRIPTION
## Summary
- replace `Address` column with `Bind`
- remove duplicated `:port` from the last column
- normalize wildcard bind display (`*` -> `0.0.0.0`)

## Linked Issue
Closes #18

## What Changed
- updated table column title and value rendering in `internal/tui/table.go`
- added bind-host formatting helper for IPv4/IPv6/wildcard cases
- added tests in `internal/tui/table_test.go`

## Validation
- [x] `go test ./...`
- [x] `go build ./...`

## Checklist
- [x] Branch name follows convention
- [x] PR scope matches linked issue
- [x] No unrelated changes included